### PR TITLE
Provide a cleaner gallery of projects with separate project pages

### DIFF
--- a/docs/myst.yml
+++ b/docs/myst.yml
@@ -14,6 +14,13 @@ project:
     - file: get_help.md
     - file: rse.md
     - file: projects.md
+      children:
+        - file: projects/bigsmiles.md
+        - file: projects/blackholes.md
+        - file: projects/ding-dash.md
+        - file: projects/dtor.md
+        - file: projects/neural-chaos.md
+        - file: projects/dusty-disks.md
     - title: Workshops
       children:
         - title: GitHub Actions workflows for reproducible science

--- a/docs/projects.md
+++ b/docs/projects.md
@@ -2,96 +2,59 @@
 title: Software Projects
 ---
 
-::::{grid} 1 1 2 2
+---
+title: Software Projects
+---
+
+::::{grid} 1 2 3 3
+:class: projects-gallery
 
 :::{card}
-:link: https://github.com/chicago-aiscience/schneider-bigsmiles-gen
 :header: `gbigsmiles`
+:link: projects/bigsmiles
 ```{image} images/gen_big_smiles_resized.png
 ```
-
-# Generative BigSMILES: (G-BigSMILES)
-
-> Authors: Ludwig Schneider, Dylan Walsh, Bradley Olsen, Juan de Pablo
-
-{button}`GitHub Repository <https://github.com/chicago-aiscience/schneider-bigsmiles-gen>`
-
-*This code implements a parser for an extension of the original bigSMILES notation.*
+*A parser for an extension of the BigSMILES notation.*
 :::
 
 :::{card}
-:link: https://github.com/chicago-aiscience/callister-autoregressive-black-holes
 :header: `autoregressive-bbh-inference`
+:link: projects/blackholes
 ```{image} images/blackholes_resized.png
 ```
-
-# A Parameter-Free Tour of the Binary Black Hole Population
-
-> Authors: Thomas A. Callister and Will M. Farr
-
-{button}`GitHub Repository <https://github.com/chicago-aiscience/callister-autoregressive-black-holes>`
-
-*This repository holds code and data release products behind the paper "A parameter-free tour of the binary black hole population".*
+*A Parameter-Free Tour of the Binary Black Hole Population.*
 :::
 
 :::{card}
-:link: https://github.com/chicago-aiscience/ding-dash
 :header: `ding-dash`
+:link: projects/ding-dash
 ```{image} images/dash_workflow_resized.png
 ```
-
-#  Ding-DASH
-
-> Authors: Rui Ding, Jianguo Liu, Kang Hua, Xuebin Wang, Xiaoben Zhang, Minhua Shao, Yuxin Chen, Junhong Chen
-
-{button}`GitHub Repository <https://github.com/chicago-aiscience/ding-dash>`
-
-*This is the online repository that stores code, data and supplementary figures of the research work: Leveraging Data Mining, Active Learning, and Domain Adaptation in a Multi-Stage, Machine Learning-Driven Approach for the Efficient Discovery of Advanced Acidic Oxygen Evolution Electrocatalysts*
+*Research work: Leveraging Data Mining, Active Learning, and Domain Adaptation in a Multi-Stage, Machine Learning-Driven Approach for the Efficient Discovery of Advanced Acidic Oxygen Evolution Electrocatalysts.*
 :::
 
 :::{card}
-:link: https://github.com/ruiding-uchicago/DToR_deep_research
 :header: `dtor`
+:link: projects/dtor
 ```{image} images/dtor_resized.png
 ```
-
-# Deep Tree of Research (DToR)
-
-> Authors: Rui Ding
-
-<!-- {button}`GitHub Repository <https://github.com/ruiding-uchicago/DToR_deep_research>` -->
-
-*DToR is a LangGraph-based research assistant that generates comprehensive reports for research topics. It supports both single-path research loops and Deep Tree of Research (DToR) routing, enabling multi-branch exploration of research questions with automated synthesis and reflection.*
+*LangGraph-based research assistant that generates comprehensive reports for research topics.*
 :::
 
 :::{card}
-:link: https://github.com/chicago-aiscience/lu-neural-chaos
 :header: `lu-neural-chaos`
+:link: projects/neural-chaos
 ```{image} images/neural_chaos_resized.png
 ```
-
-# Trailing Neural Operators
-
-> Authors: Ruoxi Jiang, Peter Lu, Elena Orlova, Rebecca Willett
-
-{button}`GitHub Repository <https://github.com/chicago-aiscience/lu-neural-chaos>`
-
-*This is the implementation for the NeurIPS 2023 paper "Training neural operators to preserve invariant measures of chaotic attractors".*
+*Implementation for the NeurIPS 2023 paper "Training neural operators to preserve invariant measures of chaotic attractors".*
 :::
 
 :::{card}
-:link: https://github.com/chicago-aiscience/lu-neural-chaos
 :header: `diff-inst`
+:link: projects/dusty-disks
 ```{image} images/diff_inst.png
 ```
-
-# Diffusive Instabilities in Dusty Disks
-
-> Authors: Konstantin Gerbig
-
-{button}`GitHub Repository <https://github.com/KonstantinGerbig/diff-inst>`
-
-*Fast, reproducible 1D axisymmetric experiments for the diffusive instability in dusty disks (Gerbig et al. 2024; doi:10.3847/1538-4357/ad1114, Gerbig & Lin, submitted), including an incompressible, viscous gas that responds azimuthally and couples to the dust via drag backreaction.*
+*Fast, reproducible 1D axisymmetric experiments for the diffusive instability in dusty disks.*
 :::
 
 ::::

--- a/docs/projects/bigsmiles.md
+++ b/docs/projects/bigsmiles.md
@@ -1,0 +1,18 @@
+---
+title: Generative BigSMILES
+---
+
+:::{card}
+:link: https://github.com/chicago-aiscience/schneider-bigsmiles-gen
+:header: `gbigsmiles`
+```{image} ../images/gen_big_smiles_resized.png
+```
+
+# Generative BigSMILES: (G-BigSMILES)
+
+> Authors: Ludwig Schneider, Dylan Walsh, Bradley Olsen, Juan de Pablo
+
+{button}`GitHub Repository <https://github.com/chicago-aiscience/schneider-bigsmiles-gen>`
+
+*This code implements a parser for an extension of the original bigSMILES notation.*
+:::

--- a/docs/projects/blackholes.md
+++ b/docs/projects/blackholes.md
@@ -1,0 +1,14 @@
+:::{card}
+:link: https://github.com/chicago-aiscience/callister-autoregressive-black-holes
+:header: `autoregressive-bbh-inference`
+```{image} ../images/blackholes_resized.png
+```
+
+# A Parameter-Free Tour of the Binary Black Hole Population
+
+> Authors: Thomas A. Callister and Will M. Farr
+
+{button}`GitHub Repository <https://github.com/chicago-aiscience/callister-autoregressive-black-holes>`
+
+*This repository holds code and data release products behind the paper "A parameter-free tour of the binary black hole population".*
+:::

--- a/docs/projects/ding-dash.md
+++ b/docs/projects/ding-dash.md
@@ -1,0 +1,14 @@
+:::{card}
+:link: https://github.com/chicago-aiscience/ding-dash
+:header: `ding-dash`
+```{image} ../images/dash_workflow_resized.png
+```
+
+#  Ding-DASH
+
+> Authors: Rui Ding, Jianguo Liu, Kang Hua, Xuebin Wang, Xiaoben Zhang, Minhua Shao, Yuxin Chen, Junhong Chen
+
+{button}`GitHub Repository <https://github.com/chicago-aiscience/ding-dash>`
+
+*This is the online repository that stores code, data and supplementary figures of the research work: Leveraging Data Mining, Active Learning, and Domain Adaptation in a Multi-Stage, Machine Learning-Driven Approach for the Efficient Discovery of Advanced Acidic Oxygen Evolution Electrocatalysts*
+:::

--- a/docs/projects/dtor.md
+++ b/docs/projects/dtor.md
@@ -1,0 +1,16 @@
+:::{card}
+
+`dtor`
+^^^
+
+```{image} ../images/dtor_resized.png
+```
+
+# Deep Tree of Research (DToR)
+
+> Authors: Rui Ding
+
+<!-- {button}`GitHub Repository <https://github.com/ruiding-uchicago/DToR_deep_research>` -->
+
+*DToR is a LangGraph-based research assistant that generates comprehensive reports for research topics. It supports both single-path research loops and Deep Tree of Research (DToR) routing, enabling multi-branch exploration of research questions with automated synthesis and reflection.*
+:::

--- a/docs/projects/dusty-disks.md
+++ b/docs/projects/dusty-disks.md
@@ -1,0 +1,14 @@
+:::{card}
+:link: https://github.com/KonstantinGerbig/diff-inst
+:header: `diff-inst`
+```{image} ../images/diff_inst.png
+```
+
+# Diffusive Instabilities in Dusty Disks
+
+> Authors: Konstantin Gerbig
+
+{button}`GitHub Repository <https://github.com/KonstantinGerbig/diff-inst>`
+
+*Fast, reproducible 1D axisymmetric experiments for the diffusive instability in dusty disks (Gerbig et al. 2024; doi:10.3847/1538-4357/ad1114, Gerbig & Lin, submitted), including an incompressible, viscous gas that responds azimuthally and couples to the dust via drag backreaction.*
+:::

--- a/docs/projects/neural-chaos.md
+++ b/docs/projects/neural-chaos.md
@@ -1,0 +1,14 @@
+:::{card}
+:link: https://github.com/chicago-aiscience/lu-neural-chaos
+:header: `lu-neural-chaos`
+```{image} ../images/neural_chaos_resized.png
+```
+
+# Trailing Neural Operators
+
+> Authors: Ruoxi Jiang, Peter Lu, Elena Orlova, Rebecca Willett
+
+{button}`GitHub Repository <https://github.com/chicago-aiscience/lu-neural-chaos>`
+
+*This is the implementation for the NeurIPS 2023 paper "Training neural operators to preserve invariant measures of chaotic attractors".*
+:::

--- a/docs/styles/custom.css
+++ b/docs/styles/custom.css
@@ -79,3 +79,27 @@ article.content img[alt="GitHub Actions"] {
   box-shadow: 0 0 0 2px rgba(0, 0, 0, 0.25);
   border-radius: 6px;
 }
+
+/* Gallery layout for projects */
+.projects-gallery .myst-card-body {
+  position: relative;
+  overflow: hidden;
+}
+
+.projects-gallery .myst-card-body p:last-child {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  margin: 0;
+  padding: 0.5rem 0.75rem;
+  background: rgba(0, 0, 0, 0.65);
+  color: white;
+  opacity: 0;
+  transition: opacity 0.25s ease;
+}
+
+.projects-gallery .myst-card:hover .myst-card-body p:last-child {
+  opacity: 1;
+}
+


### PR DESCRIPTION
- Re-organize the gallery of projects so it is easier to view an overview plus individual project detail pages.
- Added new projects: AugerNet and cEBMF + 2026 hackathon projects: gen chem and clinical kg
